### PR TITLE
enable setting specific authorities

### DIFF
--- a/packages/sdk/src/templates/arcadeToken.ts
+++ b/packages/sdk/src/templates/arcadeToken.ts
@@ -21,9 +21,13 @@ import { createNoopSigner } from 'gill';
  * @param symbol - The symbol of the arcade token.
  * @param decimals - The number of decimals for the arcade token.
  * @param uri - The URI pointing to the arcade token's metadata.
- * @param authority - The address with authority over the mint.
+ * @param mintAuthority - The address with authority over the mint.
  * @param mint - The address of the mint account to initialize.
  * @param feePayer - The address that will pay the transaction fees.
+ * @param metadataAuthority - The address with authority over the metadata.
+ * @param pausableAuthority - The address with authority over the pausable functionality.
+ * @param confidentialBalancesAuthority - The address with authority over the confidential balances extension.
+ * @param permanentDelegateAuthority - The address with authority over the permanent delegate.
  * @returns A promise that resolves to a FullTransaction object for initializing the arcade token mint.
  */
 export const createArcadeTokenInitTransaction = async (
@@ -32,16 +36,20 @@ export const createArcadeTokenInitTransaction = async (
   symbol: string,
   decimals: number,
   uri: string,
-  authority: Address,
+  mintAuthority: Address,
   mint: Address,
-  feePayer: Address
+  feePayer: Address,
+  metadataAuthority?: Address,
+  pausableAuthority?: Address,
+  confidentialBalancesAuthority?: Address,
+  permanentDelegateAuthority?: Address
 ): Promise<
   FullTransaction<TransactionVersion, TransactionMessageWithFeePayer>
 > => {
   const tx = await new Token()
     .withMetadata({
       mintAddress: mint,
-      authority: authority,
+      authority: metadataAuthority || mintAuthority,
       metadata: {
         name,
         symbol,
@@ -50,14 +58,14 @@ export const createArcadeTokenInitTransaction = async (
       // TODO: add additional metadata
       additionalMetadata: new Map(),
     })
-    .withPausable(authority)
+    .withPausable(pausableAuthority || mintAuthority)
     .withDefaultAccountState(true)
-    .withConfidentialBalances(authority)
-    .withPermanentDelegate(authority)
+    .withConfidentialBalances(confidentialBalancesAuthority || mintAuthority)
+    .withPermanentDelegate(permanentDelegateAuthority || mintAuthority)
     .buildTransaction({
       rpc,
       decimals,
-      authority,
+      authority: mintAuthority,
       mint: createNoopSigner(mint),
       feePayer: createNoopSigner(feePayer),
     });

--- a/packages/sdk/src/templates/stablecoin.ts
+++ b/packages/sdk/src/templates/stablecoin.ts
@@ -20,9 +20,13 @@ import { createNoopSigner } from 'gill';
  * @param symbol - The symbol of the stablecoin.
  * @param decimals - The number of decimals for the stablecoin.
  * @param uri - The URI pointing to the stablecoin's metadata.
- * @param authority - The address with authority over the mint.
+ * @param mintAuthority - The address with authority over the mint.
  * @param mint - The address of the mint account to initialize.
  * @param feePayer - The address that will pay the transaction fees.
+ * @param metadataAuthority - The address with authority over the metadata.
+ * @param pausableAuthority - The address with authority over the pausable functionality.
+ * @param confidentialBalancesAuthority - The address with authority over the confidential balances extension.
+ * @param permanentDelegateAuthority - The address with authority over the permanent delegate.
  * @returns A promise that resolves to a FullTransaction object for initializing the stablecoin mint.
  */
 export const createStablecoinInitTransaction = async (
@@ -31,16 +35,20 @@ export const createStablecoinInitTransaction = async (
   symbol: string,
   decimals: number,
   uri: string,
-  authority: Address,
+  mintAuthority: Address,
   mint: Address,
-  feePayer: Address
+  feePayer: Address,
+  metadataAuthority?: Address,
+  pausableAuthority?: Address,
+  confidentialBalancesAuthority?: Address,
+  permanentDelegateAuthority?: Address
 ): Promise<
   FullTransaction<TransactionVersion, TransactionMessageWithFeePayer>
 > => {
   const tx = await new Token()
     .withMetadata({
       mintAddress: mint,
-      authority: authority,
+      authority: metadataAuthority || mintAuthority,
       metadata: {
         name,
         symbol,
@@ -49,14 +57,14 @@ export const createStablecoinInitTransaction = async (
       // TODO: add additional metadata
       additionalMetadata: new Map(),
     })
-    .withPausable(authority)
+    .withPausable(pausableAuthority || mintAuthority)
     .withDefaultAccountState(true)
-    .withConfidentialBalances(authority)
-    .withPermanentDelegate(authority)
+    .withConfidentialBalances(confidentialBalancesAuthority || mintAuthority)
+    .withPermanentDelegate(permanentDelegateAuthority || mintAuthority)
     .buildTransaction({
       rpc,
       decimals,
-      authority,
+      authority: mintAuthority,
       mint: createNoopSigner(mint),
       feePayer: createNoopSigner(feePayer),
     });


### PR DESCRIPTION
## Add Granular Authority Control to Token Templates

### Summary
This PR enhances the arcade token and stablecoin template functions by introducing granular authority control, allowing developers to specify different authorities for various token functionalities instead of using a single authority for all operations.

### 🚀 Changes Made

#### Enhanced Function Signatures
- **Renamed**: `authority` parameter → `mintAuthority` for clarity
- **Added** optional authority parameters:
  - `metadataAuthority` - Controls token metadata operations
  - `pausableAuthority` - Controls pause/unpause functionality  
  - `confidentialBalancesAuthority` - Controls confidential balance features
  - `permanentDelegateAuthority` - Controls permanent delegate operations

#### Updated Functions
- `createArcadeTokenInitTransaction()` in `packages/sdk/src/templates/arcadeToken.ts`
- `createStablecoinInitTransaction()` in `packages/sdk/src/templates/stablecoin.ts`

### 🔄 Migration Guide

**Existing Code** (still works):
```typescript
createArcadeTokenInitTransaction(rpc, name, symbol, decimals, uri, authority, mint, feePayer)
```

**New Capabilities**:
```typescript
createArcadeTokenInitTransaction(
  rpc, name, symbol, decimals, uri, 
  mintAuthority, mint, feePayer,
  metadataAuthority,      // optional
  pausableAuthority,      // optional  
  confidentialBalancesAuthority, // optional
  permanentDelegateAuthority     // optional
)
```

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Introduces granular authority control to token templates, allowing specific authority assignments for various token operations.
> 
>   - **Function Signatures**:
>     - Renamed `authority` to `mintAuthority` in `createArcadeTokenInitTransaction()` and `createStablecoinInitTransaction()`.
>     - Added optional parameters: `metadataAuthority`, `pausableAuthority`, `confidentialBalancesAuthority`, `permanentDelegateAuthority`.
>   - **Behavior**:
>     - `createArcadeTokenInitTransaction()` in `arcadeToken.ts` and `createStablecoinInitTransaction()` in `stablecoin.ts` now support separate authorities for metadata, pausable functionality, confidential balances, and permanent delegate.
>     - Default to `mintAuthority` if specific authorities are not provided.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gitteri%2Fmosaic&utm_source=github&utm_medium=referral)<sup> for 37635f55b6167989c6b394e5795b612da64e87f3. You can [customize](https://app.ellipsis.dev/gitteri/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->