### PR TITLE
Add CLI Command for Creating Arcade Tokens

### DIFF
--- a/packages/cli/src/commands/create/arcade-token.ts
+++ b/packages/cli/src/commands/create/arcade-token.ts
@@ -1,7 +1,7 @@
 import { Command } from 'commander';
 import chalk from 'chalk';
 import ora from 'ora';
-import { createStablecoinInitTransaction } from '@mosaic/sdk';
+import { createArcadeTokenInitTransaction } from '@mosaic/sdk';
 import { createSolanaClient } from '../../utils/rpc.js';
 import { loadKeypair } from '../../utils/solana.js';
 import {
@@ -10,7 +10,7 @@ import {
   type Address,
 } from 'gill';
 
-interface StablecoinOptions {
+interface ArcadeTokenOptions {
   name: string;
   symbol: string;
   decimals: string;
@@ -18,18 +18,17 @@ interface StablecoinOptions {
   mintAuthority?: string;
   metadataAuthority?: string;
   pausableAuthority?: string;
-  confidentialBalancesAuthority?: string;
   permanentDelegateAuthority?: string;
   mintKeypair?: string;
   rpcUrl?: string;
   keypair?: string;
 }
 
-export const createStablecoinCommand = new Command('stablecoin')
-  .description('Create a new stablecoin with Token-2022 extensions')
+export const createArcadeTokenCommand = new Command('arcade-token')
+  .description('Create a new arcade token with Token-2022 extensions')
   .requiredOption('-n, --name <name>', 'Token name')
   .requiredOption('-s, --symbol <symbol>', 'Token symbol')
-  .option('-d, --decimals <decimals>', 'Number of decimals', '6')
+  .option('-d, --decimals <decimals>', 'Number of decimals', '0')
   .option('-u, --uri <uri>', 'Metadata URI', '')
   .option(
     '--mint-authority <address>',
@@ -44,10 +43,6 @@ export const createStablecoinCommand = new Command('stablecoin')
     'Pausable authority address (defaults to mint authority)'
   )
   .option(
-    '--confidential-balances-authority <address>',
-    'Confidential balances authority address (defaults to mint authority)'
-  )
-  .option(
     '--permanent-delegate-authority <address>',
     'Permanent delegate authority address (defaults to mint authority)'
   )
@@ -55,8 +50,8 @@ export const createStablecoinCommand = new Command('stablecoin')
     '--mint-keypair <path>',
     'Path to mint keypair file (generates new one if not provided)'
   )
-  .action(async (options: StablecoinOptions, command) => {
-    const spinner = ora('Creating stablecoin...').start();
+  .action(async (options: ArcadeTokenOptions, command) => {
+    const spinner = ora('Creating arcade token...').start();
 
     try {
       // Get global options from parent command
@@ -93,15 +88,13 @@ export const createStablecoinCommand = new Command('stablecoin')
         mintAuthority) as Address;
       const pausableAuthority = (options.pausableAuthority ||
         mintAuthority) as Address;
-      const confidentialBalancesAuthority =
-        (options.confidentialBalancesAuthority || mintAuthority) as Address;
       const permanentDelegateAuthority = (options.permanentDelegateAuthority ||
         mintAuthority) as Address;
 
       spinner.text = 'Building transaction...';
 
-      // Create stablecoin transaction
-      const transaction = await createStablecoinInitTransaction(
+      // Create arcade token transaction
+      const transaction = await createArcadeTokenInitTransaction(
         rpc,
         options.name,
         options.symbol,
@@ -112,25 +105,24 @@ export const createStablecoinCommand = new Command('stablecoin')
         signerKeypair,
         metadataAuthority,
         pausableAuthority,
-        confidentialBalancesAuthority,
+        undefined, // Arcade tokens don't use confidential balances
         permanentDelegateAuthority
       );
 
       spinner.text = 'Signing transaction...';
 
-      // Sign the transaction (buildTransaction includes signers but doesn't auto-sign)
-      const signedTransaction =
-        await signTransactionMessageWithSigners(transaction);
+      // Sign the transaction
+      const signedTransaction = await signTransactionMessageWithSigners(transaction);
 
       spinner.text = 'Sending transaction...';
 
       // Send and confirm transaction
       const signature = await sendAndConfirmTransaction(signedTransaction);
 
-      spinner.succeed('Stablecoin created successfully!');
+      spinner.succeed('Arcade token created successfully!');
 
       // Display results
-      console.log(chalk.green('✅ Stablecoin Creation Successful'));
+      console.log(chalk.green('✅ Arcade Token Creation Successful'));
       console.log(chalk.cyan('📋 Details:'));
       console.log(`   ${chalk.bold('Name:')} ${options.name}`);
       console.log(`   ${chalk.bold('Symbol:')} ${options.symbol}`);
@@ -147,24 +139,25 @@ export const createStablecoinCommand = new Command('stablecoin')
         `   ${chalk.bold('Pausable Authority:')} ${pausableAuthority}`
       );
       console.log(
-        `   ${chalk.bold('Confidential Balances Authority:')} ${confidentialBalancesAuthority}`
-      );
-      console.log(
         `   ${chalk.bold('Permanent Delegate Authority:')} ${permanentDelegateAuthority}`
       );
 
-      console.log(chalk.cyan('🛡️ Token Extensions:'));
-      console.log(`   ${chalk.green('✓')} Metadata`);
+      console.log(chalk.cyan('🎮 Token Extensions:'));
+      console.log(`   ${chalk.green('✓')} Metadata (Rich Gaming Metadata)`);
       console.log(`   ${chalk.green('✓')} Pausable`);
-      console.log(`   ${chalk.green('✓')} Default Account State (Blocklist)`);
-      console.log(`   ${chalk.green('✓')} Confidential Balances`);
+      console.log(`   ${chalk.green('✓')} Default Account State (Allowlist)`);
+      console.log(
+        chalk.yellow(
+          '     ⚠️  You must add addresses to the allowlist for your arcade token to be usable by end users.'
+        )
+      );
       console.log(`   ${chalk.green('✓')} Permanent Delegate`);
 
       if (options.uri) {
         console.log(`${chalk.bold('Metadata URI:')} ${options.uri}`);
       }
     } catch (error) {
-      spinner.fail('Failed to create stablecoin');
+      spinner.fail('Failed to create arcade token');
       console.error(
         chalk.red('❌ Error:'),
         error instanceof Error ? error.message : 'Unknown error'

--- a/packages/cli/src/commands/create/arcade-token.ts
+++ b/packages/cli/src/commands/create/arcade-token.ts
@@ -112,7 +112,8 @@ export const createArcadeTokenCommand = new Command('arcade-token')
       spinner.text = 'Signing transaction...';
 
       // Sign the transaction
-      const signedTransaction = await signTransactionMessageWithSigners(transaction);
+      const signedTransaction =
+        await signTransactionMessageWithSigners(transaction);
 
       spinner.text = 'Sending transaction...';
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2,6 +2,7 @@
 
 import { Command } from 'commander';
 import { createStablecoinCommand } from './commands/create/stablecoin.js';
+import { createArcadeTokenCommand } from './commands/create/arcade-token.js';
 
 const program = new Command();
 
@@ -15,8 +16,9 @@ const createCommand = program
   .command('create')
   .description('Create new tokens with Token-2022 extensions');
 
-// Add stablecoin creation command
+// Add token creation commands
 createCommand.addCommand(createStablecoinCommand);
+createCommand.addCommand(createArcadeTokenCommand);
 
 // Global options
 program

--- a/packages/sdk/src/templates/arcadeToken.ts
+++ b/packages/sdk/src/templates/arcadeToken.ts
@@ -6,6 +6,8 @@ import type {
   FullTransaction,
   TransactionMessageWithFeePayer,
   TransactionVersion,
+  TransactionSigner,
+  TransactionWithBlockhashLifetime,
 } from 'gill';
 import { createNoopSigner } from 'gill';
 
@@ -37,18 +39,20 @@ export const createArcadeTokenInitTransaction = async (
   decimals: number,
   uri: string,
   mintAuthority: Address,
-  mint: Address,
-  feePayer: Address,
+  mint: Address | TransactionSigner<string>,
+  feePayer: Address | TransactionSigner<string>,
   metadataAuthority?: Address,
   pausableAuthority?: Address,
   confidentialBalancesAuthority?: Address,
   permanentDelegateAuthority?: Address
 ): Promise<
-  FullTransaction<TransactionVersion, TransactionMessageWithFeePayer>
+  FullTransaction<TransactionVersion, TransactionMessageWithFeePayer, TransactionWithBlockhashLifetime>
 > => {
+  const mintSigner = typeof mint === 'string' ? createNoopSigner(mint) : mint;
+  const feePayerSigner = typeof feePayer === 'string' ? createNoopSigner(feePayer) : feePayer;
   const tx = await new Token()
     .withMetadata({
-      mintAddress: mint,
+      mintAddress: mintSigner.address,
       authority: metadataAuthority || mintAuthority,
       metadata: {
         name,
@@ -66,8 +70,8 @@ export const createArcadeTokenInitTransaction = async (
       rpc,
       decimals,
       authority: mintAuthority,
-      mint: createNoopSigner(mint),
-      feePayer: createNoopSigner(feePayer),
+      mint: mintSigner,
+      feePayer: feePayerSigner,
     });
 
   return tx;

--- a/packages/sdk/src/templates/arcadeToken.ts
+++ b/packages/sdk/src/templates/arcadeToken.ts
@@ -46,10 +46,15 @@ export const createArcadeTokenInitTransaction = async (
   confidentialBalancesAuthority?: Address,
   permanentDelegateAuthority?: Address
 ): Promise<
-  FullTransaction<TransactionVersion, TransactionMessageWithFeePayer, TransactionWithBlockhashLifetime>
+  FullTransaction<
+    TransactionVersion,
+    TransactionMessageWithFeePayer,
+    TransactionWithBlockhashLifetime
+  >
 > => {
   const mintSigner = typeof mint === 'string' ? createNoopSigner(mint) : mint;
-  const feePayerSigner = typeof feePayer === 'string' ? createNoopSigner(feePayer) : feePayer;
+  const feePayerSigner =
+    typeof feePayer === 'string' ? createNoopSigner(feePayer) : feePayer;
   const tx = await new Token()
     .withMetadata({
       mintAddress: mintSigner.address,


### PR DESCRIPTION
## Add CLI Command for Creating Arcade Tokens

### Overview
This PR adds a new CLI command `mosaic create arcade-token` that enables developers to easily create arcade tokens with gaming-specific Token-2022 extensions directly from the command line.

### What's New
- **New CLI Command**: `mosaic create arcade-token` with comprehensive options for token configuration
- **Gaming-Focused Token Creation**: Streamlined creation of tokens designed for arcade and gaming applications
- **Enhanced SDK Integration**: Improved type safety and transaction signer handling in the arcade token template

### Features
The new command creates tokens with the following extensions enabled by default:
- ✅ **Metadata Extension**: Rich gaming metadata support  
- ✅ **Pausable**: Authority-controlled pause/unpause functionality
- ✅ **Default Account State**: Built-in allowlist capabilities for closed-loop token economies
- ✅ **Permanent Delegate**: Enhanced control and management features

### CLI Usage
```bash
# Basic arcade token creation
mosaic create arcade-token -n "GameCoin" -s "GAME"

# Advanced options with custom authorities
mosaic create arcade-token \
  -n "ArcadeCoin" \
  -s "ARC" \
  -d 2 \
  --mint-authority <address> \
  --pausable-authority <address> \
  --metadata-authority <address>
```

### Changes Made
1. **New CLI Command** (`packages/cli/src/commands/create/arcade-token.ts`)
   - Comprehensive option handling for all token configuration
   - Rich console output with color-coded success messages
   - Proper error handling and user feedback
   - Automatic keypair generation or custom keypair loading

2. **SDK Template Improvements** (`packages/sdk/src/templates/arcadeToken.ts`)
   - Enhanced type safety with `TransactionSigner` support
   - Better handling of mint and fee payer signers
   - Improved transaction return types

3. **CLI Integration** (`packages/cli/src/index.ts`)
   - Added arcade token command to the create command group

### Target Use Cases
- Gaming developers building on-chain economies
- Arcade operators creating allowlist-controlled tokens
- Projects requiring pausable token functionality
- Applications needing rich metadata for gaming assets

### Note for Users
⚠️ **Important**: Arcade tokens are created with a default account state that requires allowlisting. You must add addresses to the allowlist for your arcade token to be usable by end users.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a new CLI command for creating arcade tokens with Token-2022 extensions, improves SDK integration, and updates CLI to include the new command.
> 
>   - **New CLI Command**:
>     - Adds `mosaic create arcade-token` in `arcade-token.ts` for creating arcade tokens with Token-2022 extensions.
>     - Supports options for token configuration, including authorities and metadata URI.
>     - Provides console output for success and error handling.
>   - **SDK Template Improvements**:
>     - Enhances `createArcadeTokenInitTransaction` in `arcadeToken.ts` with better type safety and transaction handling.
>     - Supports `TransactionSigner` for mint and fee payer.
>   - **CLI Integration**:
>     - Adds `createArcadeTokenCommand` to `index.ts` under the create command group.
>     - Updates CLI to manage arcade tokens with enhanced options for gaming applications.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gitteri%2Fmosaic&utm_source=github&utm_medium=referral)<sup> for 140ac9545ab030c384b48a45a8f3e1c52958c891. You can [customize](https://app.ellipsis.dev/gitteri/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->