### PR TITLE
add mint to command

### DIFF
--- a/packages/cli/src/commands/mint.ts
+++ b/packages/cli/src/commands/mint.ts
@@ -1,0 +1,119 @@
+import { Command } from 'commander';
+import chalk from 'chalk';
+import ora from 'ora';
+import {
+  createMintToTransaction,
+  getMintInfo,
+  decimalAmountToRaw,
+} from '@mosaic/sdk';
+import { createSolanaClient } from '../utils/rpc.js';
+import { loadKeypair } from '../utils/solana.js';
+import { signTransactionMessageWithSigners, type Address } from 'gill';
+
+interface MintOptions {
+  mintAddress: string;
+  recipient: string;
+  amount: string;
+  rpcUrl?: string;
+  keypair?: string;
+}
+
+export const mintCommand = new Command('mint')
+  .description('Mint tokens to a recipient address')
+  .requiredOption(
+    '-m, --mint-address <mint-address>',
+    'The mint address of the token'
+  )
+  .requiredOption(
+    '-r, --recipient <recipient>',
+    'The recipient wallet address (ATA owner)'
+  )
+  .requiredOption(
+    '-a, --amount <amount>',
+    'The decimal amount to mint (e.g., 1.5)'
+  )
+  .action(async (options: MintOptions, command) => {
+    const spinner = ora('Minting tokens...').start();
+
+    try {
+      // Get global options from parent command
+      const parentOpts = command.parent?.opts() || {};
+      const rpcUrl = options.rpcUrl || parentOpts.rpcUrl;
+      const keypairPath = options.keypair || parentOpts.keypair;
+
+      // Create Solana client
+      const { rpc, sendAndConfirmTransaction } = createSolanaClient(rpcUrl);
+
+      // Load mint authority keypair (assuming it's the configured keypair)
+      const mintAuthorityKeypair = await loadKeypair(keypairPath);
+
+      spinner.text = 'Getting mint information...';
+
+      // Get mint info to determine decimals
+      const mintInfo = await getMintInfo(rpc, options.mintAddress as Address);
+      const decimals = mintInfo.decimals;
+
+      // Parse and validate amount
+      const decimalAmount = parseFloat(options.amount);
+      if (isNaN(decimalAmount) || decimalAmount <= 0) {
+        throw new Error('Amount must be a positive number');
+      }
+
+      // Convert decimal amount to raw amount
+      const rawAmount = decimalAmountToRaw(decimalAmount, decimals);
+
+      spinner.text = 'Building mint transaction...';
+
+      // Create mint transaction
+      const transaction = await createMintToTransaction(
+        rpc,
+        options.mintAddress as Address,
+        options.recipient as Address,
+        rawAmount,
+        mintAuthorityKeypair,
+        mintAuthorityKeypair // Use same keypair as fee payer
+      );
+
+      spinner.text = 'Signing transaction...';
+
+      // Sign the transaction
+      const signedTransaction =
+        await signTransactionMessageWithSigners(transaction);
+
+      spinner.text = 'Sending transaction...';
+
+      // Send and confirm transaction
+      const signature = await sendAndConfirmTransaction(signedTransaction);
+
+      spinner.succeed('Tokens minted successfully!');
+
+      // Display results
+      console.log(chalk.green('✅ Mint Transaction Successful'));
+      console.log(chalk.cyan('📋 Details:'));
+      console.log(`   ${chalk.bold('Mint Address:')} ${options.mintAddress}`);
+      console.log(`   ${chalk.bold('Recipient:')} ${options.recipient}`);
+      console.log(
+        `   ${chalk.bold('Amount:')} ${decimalAmount} (${rawAmount.toString()} raw units)`
+      );
+      console.log(`   ${chalk.bold('Decimals:')} ${decimals}`);
+      console.log(`   ${chalk.bold('Transaction:')} ${signature}`);
+      console.log(
+        `   ${chalk.bold('Mint Authority:')} ${mintAuthorityKeypair.address}`
+      );
+
+      console.log(chalk.cyan('\\n🎯 Result:'));
+      console.log(
+        `   ${chalk.green('✓')} Associated Token Account created/updated`
+      );
+      console.log(
+        `   ${chalk.green('✓')} ${decimalAmount} tokens minted to recipient`
+      );
+    } catch (error) {
+      spinner.fail('Failed to mint tokens');
+      console.error(
+        chalk.red('\\n❌ Error:'),
+        error instanceof Error ? error : 'Unknown error'
+      );
+      process.exit(1);
+    }
+  });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -3,6 +3,7 @@
 import { Command } from 'commander';
 import { createStablecoinCommand } from './commands/create/stablecoin.js';
 import { createArcadeTokenCommand } from './commands/create/arcade-token.js';
+import { mintCommand } from './commands/mint.js';
 
 const program = new Command();
 
@@ -19,6 +20,9 @@ const createCommand = program
 // Add token creation commands
 createCommand.addCommand(createStablecoinCommand);
 createCommand.addCommand(createArcadeTokenCommand);
+
+// Add token management commands
+program.addCommand(mintCommand);
 
 // Global options
 program

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,2 +1,4 @@
 export { Token } from './issuance';
 export * from './templates';
+export * from './management/mint';
+export * from './transactionUtil';

--- a/packages/sdk/src/management/mint.ts
+++ b/packages/sdk/src/management/mint.ts
@@ -41,7 +41,6 @@ export const createMintToTransaction = async (
     TransactionWithBlockhashLifetime
   >
 > => {
-  console.error(recipient);
   const feePayerSigner =
     typeof feePayer === 'string' ? createNoopSigner(feePayer) : feePayer;
   const mintAuthoritySigner =

--- a/packages/sdk/src/management/mint.ts
+++ b/packages/sdk/src/management/mint.ts
@@ -1,0 +1,101 @@
+import type {
+  Address,
+  Rpc,
+  SolanaRpcApi,
+  FullTransaction,
+  TransactionMessageWithFeePayer,
+  TransactionVersion,
+  TransactionSigner,
+  TransactionWithBlockhashLifetime,
+} from 'gill';
+import { createNoopSigner, createTransaction } from 'gill';
+import {
+  getAssociatedTokenAccountAddress,
+  TOKEN_2022_PROGRAM_ADDRESS,
+  getMintTokensInstructions,
+} from 'gill/programs/token';
+
+/**
+ * Creates a transaction to mint tokens to a recipient's associated token account.
+ * Will create the ATA if it doesn't exist.
+ *
+ * @param rpc - The Solana RPC client instance
+ * @param mint - The mint address
+ * @param recipient - The recipient's wallet address (owner of the ATA)
+ * @param amount - The raw token amount (already adjusted for decimals)
+ * @param mintAuthority - The mint authority signer
+ * @param feePayer - The fee payer signer
+ * @returns A promise that resolves to a FullTransaction object for minting tokens
+ */
+export const createMintToTransaction = async (
+  rpc: Rpc<SolanaRpcApi>,
+  mint: Address,
+  recipient: Address,
+  amount: bigint,
+  mintAuthority: Address | TransactionSigner<string>,
+  feePayer: Address | TransactionSigner<string>
+): Promise<
+  FullTransaction<
+    TransactionVersion,
+    TransactionMessageWithFeePayer,
+    TransactionWithBlockhashLifetime
+  >
+> => {
+  console.error(recipient);
+  const feePayerSigner =
+    typeof feePayer === 'string' ? createNoopSigner(feePayer) : feePayer;
+  const mintAuthoritySigner =
+    typeof mintAuthority === 'string'
+      ? createNoopSigner(mintAuthority)
+      : mintAuthority;
+  const instructions = getMintTokensInstructions({
+    mint,
+    destination: recipient,
+    amount,
+    mintAuthority: mintAuthoritySigner,
+    feePayer: feePayerSigner,
+    ata: await getAssociatedTokenAccountAddress(
+      mint,
+      recipient,
+      TOKEN_2022_PROGRAM_ADDRESS
+    ),
+    tokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
+  });
+
+  // Get latest blockhash for transaction
+  const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
+
+  return createTransaction({
+    feePayer: feePayerSigner,
+    version: 'legacy',
+    latestBlockhash,
+    instructions,
+  });
+};
+
+/**
+ * Gets mint information including decimals
+ *
+ * @param rpc - The Solana RPC client instance
+ * @param mint - The mint address
+ * @returns Promise with mint information including decimals
+ */
+export async function getMintInfo(rpc: Rpc<SolanaRpcApi>, mint: Address) {
+  const accountInfo = await rpc
+    .getAccountInfo(mint, { encoding: 'base64' })
+    .send();
+
+  if (!accountInfo.value) {
+    throw new Error(`Mint account ${mint} not found`);
+  }
+
+  // Parse mint data to get decimals (simplified parsing)
+  // In Token-2022, decimals are at offset 44 in the mint account data
+  const data = Buffer.from(accountInfo.value.data[0], 'base64');
+  const decimals = data[44];
+
+  return {
+    decimals,
+    data: accountInfo.value,
+  };
+}

--- a/packages/sdk/src/transactionUtil.ts
+++ b/packages/sdk/src/transactionUtil.ts
@@ -43,3 +43,28 @@ export const transactionToB64 = (
   const compiledTransaction = compileTransaction(transaction);
   return getBase64Decoder().decode(compiledTransaction.messageBytes);
 };
+
+/**
+ * Converts a decimal amount to raw token amount based on mint decimals
+ *
+ * @param decimalAmount - The decimal amount (e.g., 1.5)
+ * @param decimals - The number of decimals the token has
+ * @returns The raw token amount as bigint
+ */
+export function decimalAmountToRaw(
+  decimalAmount: number,
+  decimals: number
+): bigint {
+  if (decimals < 0 || decimals > 9) {
+    throw new Error('Decimals must be between 0 and 9');
+  }
+
+  const multiplier = Math.pow(10, decimals);
+  const rawAmount = Math.floor(decimalAmount * multiplier);
+
+  if (rawAmount < 0) {
+    throw new Error('Amount must be positive');
+  }
+
+  return BigInt(rawAmount);
+}


### PR DESCRIPTION
## Mint Command Implementation

###  SDK Layer (packages/sdk/src/management/mint.ts)

  - createMintToTransaction() - Creates a transaction to mint tokens to a recipient's ATA
  - decimalAmountToRaw() - Converts decimal amounts to raw token amounts based on decimals
  - getMintInfo() - Retrieves mint information including decimals from the blockchain
  - Automatically creates the Associated Token Account (ATA) if it doesn't exist
  - Uses Token-2022 program throughout

###  CLI Layer (packages/cli/src/commands/mint.ts)

  - Command format: mosaic mint -m <mint-address> -r <recipient> -a <amount>
  - Arguments:
    - mint-address: The token mint address
    - recipient: The wallet address that will own the ATA
    - amount: Decimal amount (e.g., 1.5) that gets converted to raw units
  - Uses the configured Solana keypair as the mint authority (assumes you have mint authority)
  - Provides comprehensive output showing both decimal and raw amounts

###  Key Features:

  1. Automatic ATA handling - Creates recipient's ATA if it doesn't exist
  2. Decimal conversion - Automatically converts decimal amounts to raw amounts based on mint's decimals
  3. Token-2022 support - Uses TOKEN_2022_PROGRAM_ADDRESS throughout
  4. Consistent CLI patterns - Follows same error handling, spinner, and output patterns as create commands
  5. Keypair integration - Uses Solana CLI config for mint authority

###  Usage Examples:

  #### Mint 10.5 tokens to a recipient
  `mosaic mint -m EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v -r 9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM -a 10.5`

  #### Mint with custom RPC
  `mosaic mint --rpc-url https://api.mainnet-beta.solana.com -m EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v
-r  9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM -a100`

  #### Mint with custom keypair
  `mosaic mint --keypair ~/.config/solana/mint-authority.json -m <mint> -r <recipient> -a 50.25`

  The command automatically:
  - Fetches mint info to get the correct decimals
  - Converts the decimal amount to raw units (e.g., 1.5 with 6 decimals becomes 1,500,000)
  - Creates the recipient's ATA if needed
  - Mints the tokens
  - Shows detailed success information including both decimal and raw amounts


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a CLI command to mint tokens, with SDK support for transaction creation and decimal conversion.
> 
>   - **CLI**:
>     - Adds `mintCommand` in `mint.ts` to mint tokens to a recipient's ATA.
>     - Command: `mosaic mint -m <mint-address> -r <recipient> -a <amount>`.
>     - Handles automatic ATA creation and uses Solana keypair for mint authority.
>   - **SDK**:
>     - Adds `createMintToTransaction()` and `getMintInfo()` in `mint.ts` for transaction creation and mint info retrieval.
>     - Implements `decimalAmountToRaw()` in `transactionUtil.ts` for decimal to raw amount conversion.
>   - **Integration**:
>     - Integrates `mintCommand` into CLI in `index.ts`.
>     - Exports new functions in `sdk/src/index.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gitteri%2Fmosaic&utm_source=github&utm_medium=referral)<sup> for e4d4e1addfa9e5874f9db73e1bd0dbc84c8f356d. You can [customize](https://app.ellipsis.dev/gitteri/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->