### PR TITLE
Fix cli help

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,10 @@ Mosaic is a TypeScript monorepo for managing Token-2022 extensions on Solana, sp
   - Provides `Token` class for building token transactions with extensions
   - Contains predefined templates for stablecoin and arcade tokens
   - Token extensions include: Metadata, Pausable, Default Account State, Confidential Balances, Permanent Delegate
-- **@mosaic/cli** (`packages/cli/`) - Command-line interface (scaffolded)
+  - Key modules: issuance, management, administration, templates
+- **@mosaic/cli** (`packages/cli/`) - Command-line interface built with Commander.js
+  - Commands: `create stablecoin`, `create arcade-token`, `mint`
+  - Global options: `--rpc-url`, `--keypair`
 - **@mosaic/ui** (`packages/ui/`) - Next.js web interface with Tailwind CSS and Radix UI components
 
 ## Token Types
@@ -51,6 +54,9 @@ pnpm format:check      # Check formatting
 pnpm type-check        # TypeScript checking
 pnpm check             # Run format:check + lint + type-check
 
+# Clean build artifacts
+pnpm clean             # Remove dist folders from all packages
+
 # Before committing
 pnpm precommit         # format + lint:fix
 ```
@@ -63,11 +69,37 @@ pnpm precommit         # format + lint:fix
 - Main entry point exports `Token` class and templates
 - Test setup in `src/__tests__/setup.ts`
 
+```bash
+cd packages/sdk
+pnpm test:watch     # Run tests in watch mode
+pnpm test:coverage  # Generate test coverage report
+```
+
+### CLI (packages/cli/)
+
+- Uses Commander.js for CLI framework
+- Uses tsx for development execution
+- Exports mosaic binary when built
+
+```bash
+cd packages/cli
+pnpm dev           # Run CLI in development mode using tsx
+pnpm build         # Build CLI binary
+pnpm start         # Run built CLI
+```
+
 ### UI (packages/ui/)
 
 - Next.js 14 with App Router
 - Tailwind CSS + Radix UI components
 - Theme support with next-themes
+
+```bash
+cd packages/ui
+pnpm dev    # Start Next.js development server
+pnpm build  # Build for production
+pnpm start  # Start production server
+```
 
 ## Development Notes
 

--- a/packages/cli/src/commands/create/arcade-token.ts
+++ b/packages/cli/src/commands/create/arcade-token.ts
@@ -50,6 +50,11 @@ export const createArcadeTokenCommand = new Command('arcade-token')
     '--mint-keypair <path>',
     'Path to mint keypair file (generates new one if not provided)'
   )
+  .showHelpAfterError()
+  .configureHelp({
+    sortSubcommands: true,
+    subcommandTerm: (cmd) => cmd.name()
+  })
   .action(async (options: ArcadeTokenOptions, command) => {
     const spinner = ora('Creating arcade token...').start();
 

--- a/packages/cli/src/commands/create/stablecoin.ts
+++ b/packages/cli/src/commands/create/stablecoin.ts
@@ -55,6 +55,11 @@ export const createStablecoinCommand = new Command('stablecoin')
     '--mint-keypair <path>',
     'Path to mint keypair file (generates new one if not provided)'
   )
+  .showHelpAfterError()
+  .configureHelp({
+    sortSubcommands: true,
+    subcommandTerm: (cmd) => cmd.name()
+  })
   .action(async (options: StablecoinOptions, command) => {
     const spinner = ora('Creating stablecoin...').start();
 

--- a/packages/cli/src/commands/create/stablecoin.ts
+++ b/packages/cli/src/commands/create/stablecoin.ts
@@ -9,7 +9,6 @@ import {
   signTransactionMessageWithSigners,
   type Address,
 } from 'gill';
-// import {  } 
 
 interface StablecoinOptions {
   name: string;

--- a/packages/cli/src/commands/create/stablecoin.ts
+++ b/packages/cli/src/commands/create/stablecoin.ts
@@ -9,6 +9,7 @@ import {
   signTransactionMessageWithSigners,
   type Address,
 } from 'gill';
+// import {  } 
 
 interface StablecoinOptions {
   name: string;
@@ -170,10 +171,18 @@ export const createStablecoinCommand = new Command('stablecoin')
       }
     } catch (error) {
       spinner.fail('Failed to create stablecoin');
-      console.error(
-        chalk.red('❌ Error:'),
-        error instanceof Error ? error.message : 'Unknown error'
-      );
+      if ('context' in (error as any)) {
+        console.error(
+          chalk.red(`❌ Transaction simulation failed:`),
+          `\n\t${(error as any).context.logs.join('\n\t')}`
+        );
+      } else {
+        console.error(
+          chalk.red('❌ Error:'),
+          error instanceof Error ? error.message : 'Unknown error'
+        );
+
+      }
       process.exit(1);
     }
   });

--- a/packages/cli/src/commands/mint.ts
+++ b/packages/cli/src/commands/mint.ts
@@ -32,6 +32,11 @@ export const mintCommand = new Command('mint')
     '-a, --amount <amount>',
     'The decimal amount to mint (e.g., 1.5)'
   )
+  .showHelpAfterError()
+  .configureHelp({
+    sortSubcommands: true,
+    subcommandTerm: (cmd) => cmd.name()
+  })
   .action(async (options: MintOptions, command) => {
     const spinner = ora('Minting tokens...').start();
 


### PR DESCRIPTION
show all args for commands on failure

pre:
```bash
$ cli git:(main) ✗ pnpm dev create stablecoin

> @mosaic/cli@0.1.0 dev /Users/noahgundotra/Documents/mosaic/packages/cli
> tsx src/index.ts "create" "stablecoin"

error: required option '-n, --name <name>' not specified
```

post:
```bash
$ cli git:(main) ✗ pnpm dev create stablecoin

> @mosaic/cli@0.1.0 dev /Users/noahgundotra/Documents/mosaic/packages/cli
> tsx src/index.ts "create" "stablecoin"

error: required option '-n, --name <name>' not specified

Usage: mosaic create stablecoin [options]

Create a new stablecoin with Token-2022 extensions

Options:
  -n, --name <name>                            Token name
  -s, --symbol <symbol>                        Token symbol
  -d, --decimals <decimals>                    Number of decimals (default: "6")
  -u, --uri <uri>                              Metadata URI (default: "")
  --mint-authority <address>                   Mint authority address (defaults to signer)
  --metadata-authority <address>               Metadata authority address (defaults to mint authority)
  --pausable-authority <address>               Pausable authority address (defaults to mint authority)
  --confidential-balances-authority <address>  Confidential balances authority address (defaults to mint authority)
  --permanent-delegate-authority <address>     Permanent delegate authority address (defaults to mint authority)
  --mint-keypair <path>                        Path to mint keypair file (generates new one if not provided)
  -h, --help                                   display help for command
  ```