### PR TITLE
added a token creation sidebar with more information

### DIFF
--- a/packages/cli/src/commands/create/stablecoin.ts
+++ b/packages/cli/src/commands/create/stablecoin.ts
@@ -121,6 +121,7 @@ export const createStablecoinCommand = new Command('stablecoin')
         mintAuthority,
         mintKeypair,
         signerKeypair,
+        'blocklist',
         metadataAuthority,
         pausableAuthority,
         confidentialBalancesAuthority,

--- a/packages/sdk/src/templates/arcadeToken.ts
+++ b/packages/sdk/src/templates/arcadeToken.ts
@@ -76,7 +76,6 @@ export const createArcadeTokenInitTransaction = async (
     })
     .withPausable(pausableAuthority || mintAuthority)
     .withDefaultAccountState(false)
-    .withConfidentialBalances(confidentialBalancesAuthority || mintAuthority)
     .withPermanentDelegate(permanentDelegateAuthority || mintAuthority)
     .buildInstructions({
       rpc,

--- a/packages/sdk/src/templates/stablecoin.ts
+++ b/packages/sdk/src/templates/stablecoin.ts
@@ -47,6 +47,7 @@ export const createStablecoinInitTransaction = async (
   mintAuthority: Address,
   mint: Address | TransactionSigner<string>,
   feePayer: Address | TransactionSigner<string>,
+  aclMode?: 'allowlist' | 'blocklist',
   metadataAuthority?: Address,
   pausableAuthority?: Address,
   confidentialBalancesAuthority?: Address,
@@ -61,6 +62,8 @@ export const createStablecoinInitTransaction = async (
   const mintSigner = typeof mint === 'string' ? createNoopSigner(mint) : mint;
   const feePayerSigner =
     typeof feePayer === 'string' ? createNoopSigner(feePayer) : feePayer;
+
+  aclMode = aclMode || 'blocklist';
 
   // 1. create token
   const instructions = await new Token()
@@ -126,7 +129,7 @@ export const createStablecoinInitTransaction = async (
     await getCreateListInstructions({
       authority: feePayerSigner,
       mint: mintSigner.address,
-      mode: Mode.Block,
+      mode: aclMode === 'allowlist' ? Mode.Allow : Mode.Block,
     });
 
   // 6. set extra metas (abl): this is how we can change the list associated with a given mint

--- a/packages/ui/src/app/dashboard/create/arcade-token/ArcadeTokenCreateForm.tsx
+++ b/packages/ui/src/app/dashboard/create/arcade-token/ArcadeTokenCreateForm.tsx
@@ -59,6 +59,16 @@ export function ArcadeTokenCreateForm({
         // Save to local storage
         TokenStorage.saveToken(tokenDisplay);
 
+        const addrValue: unknown = (transactionSendingSigner as {
+          address?: unknown;
+        }).address;
+        const defaultAuthority =
+          typeof addrValue === 'string'
+            ? addrValue
+            : typeof addrValue === 'object' && addrValue !== null && 'toString' in addrValue
+            ? String((addrValue as { toString: () => string }).toString())
+            : '';
+
         setResult({
           success: true,
           mintAddress: result.mintAddress,
@@ -66,16 +76,17 @@ export function ArcadeTokenCreateForm({
           details: {
             ...arcadeTokenOptions,
             decimals: parseInt(arcadeTokenOptions.decimals),
-            mintAuthority: arcadeTokenOptions.mintAuthority || '',
-            metadataAuthority: arcadeTokenOptions.metadataAuthority || '',
-            pausableAuthority: arcadeTokenOptions.pausableAuthority || '',
+            mintAuthority: arcadeTokenOptions.mintAuthority || defaultAuthority,
+            metadataAuthority:
+              arcadeTokenOptions.metadataAuthority || defaultAuthority,
+            pausableAuthority:
+              arcadeTokenOptions.pausableAuthority || defaultAuthority,
             permanentDelegateAuthority:
-              arcadeTokenOptions.permanentDelegateAuthority || '',
+              arcadeTokenOptions.permanentDelegateAuthority || defaultAuthority,
             extensions: [
               'Metadata',
               'Pausable',
-              'Default Account State (Blocklist)',
-              'Confidential Balances',
+              'Default Account State (Allowlist)',
               'Permanent Delegate',
             ],
           },
@@ -113,37 +124,46 @@ export function ArcadeTokenCreateForm({
 
   return (
     <>
-      <form onSubmit={handleSubmit} className="space-y-6">
-        <ArcadeTokenBasicParams
-          options={arcadeTokenOptions}
-          onInputChange={handleInputChange}
-        />
+      {result ? (
+        <>
+          <ArcadeTokenCreationResultDisplay result={result} />
+          <div className="flex gap-4">
+            <Button type="button" variant="outline" onClick={handleReset}>
+              Create another arcade token
+            </Button>
+          </div>
+        </>
+      ) : (
+        <form onSubmit={handleSubmit} className="space-y-6">
+          <ArcadeTokenBasicParams
+            options={arcadeTokenOptions}
+            onInputChange={handleInputChange}
+          />
 
-        <ArcadeTokenAuthorityParams
-          options={arcadeTokenOptions}
-          onInputChange={handleInputChange}
-        />
+          <ArcadeTokenAuthorityParams
+            options={arcadeTokenOptions}
+            onInputChange={handleInputChange}
+          />
 
-        {result && <ArcadeTokenCreationResultDisplay result={result} />}
-
-        <div className="flex gap-4">
-          <Button
-            type="submit"
-            className="flex-1"
-            disabled={
-              isCreating ||
-              !arcadeTokenOptions.name ||
-              !arcadeTokenOptions.symbol ||
-              !arcadeTokenOptions.decimals
-            }
-          >
-            {isCreating ? 'Creating Arcade Token...' : 'Create Arcade Token'}
-          </Button>
-          <Button type="button" variant="outline" onClick={handleReset}>
-            Reset
-          </Button>
-        </div>
-      </form>
+          <div className="flex gap-4">
+            <Button
+              type="submit"
+              className="flex-1"
+              disabled={
+                isCreating ||
+                !arcadeTokenOptions.name ||
+                !arcadeTokenOptions.symbol ||
+                !arcadeTokenOptions.decimals
+              }
+            >
+              {isCreating ? 'Creating Arcade Token...' : 'Create Arcade Token'}
+            </Button>
+            <Button type="button" variant="outline" onClick={handleReset}>
+              Reset
+            </Button>
+          </div>
+        </form>
+      )}
     </>
   );
 }

--- a/packages/ui/src/app/dashboard/create/arcade-token/ArcadeTokenCreateForm.tsx
+++ b/packages/ui/src/app/dashboard/create/arcade-token/ArcadeTokenCreateForm.tsx
@@ -59,15 +59,19 @@ export function ArcadeTokenCreateForm({
         // Save to local storage
         TokenStorage.saveToken(tokenDisplay);
 
-        const addrValue: unknown = (transactionSendingSigner as {
-          address?: unknown;
-        }).address;
+        const addrValue: unknown = (
+          transactionSendingSigner as {
+            address?: unknown;
+          }
+        ).address;
         const defaultAuthority =
           typeof addrValue === 'string'
             ? addrValue
-            : typeof addrValue === 'object' && addrValue !== null && 'toString' in addrValue
-            ? String((addrValue as { toString: () => string }).toString())
-            : '';
+            : typeof addrValue === 'object' &&
+                addrValue !== null &&
+                'toString' in addrValue
+              ? String((addrValue as { toString: () => string }).toString())
+              : '';
 
         setResult({
           success: true,

--- a/packages/ui/src/app/dashboard/create/arcade-token/ArcadeTokenCreationResult.tsx
+++ b/packages/ui/src/app/dashboard/create/arcade-token/ArcadeTokenCreationResult.tsx
@@ -1,6 +1,7 @@
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Gamepad2, CheckCircle, Settings } from 'lucide-react';
+import { CopyableExplorerField } from '@/components/CopyableExplorerField';
 import { ArcadeTokenCreationResult } from '@/types/token';
 import Link from 'next/link';
 
@@ -38,18 +39,18 @@ export function ArcadeTokenCreationResultDisplay({
                 dashboard
               </span>
             </div>
-            <div>
-              <strong>Mint Address:</strong>
-              <code className="ml-2 bg-muted px-2 py-1 rounded text-sm">
-                {result.mintAddress}
-              </code>
-            </div>
-            <div>
-              <strong>Transaction:</strong>
-              <code className="ml-2 bg-muted px-2 py-1 rounded text-sm">
-                {result.transactionSignature}
-              </code>
-            </div>
+            <CopyableExplorerField
+              label="Mint Address"
+              value={result.mintAddress}
+              kind="address"
+              cluster="devnet"
+            />
+            <CopyableExplorerField
+              label="Transaction"
+              value={result.transactionSignature}
+              kind="tx"
+              cluster="devnet"
+            />
             <div className="text-sm text-muted-foreground">
               Your arcade token has been successfully created with the following
               parameters:
@@ -63,6 +64,9 @@ export function ArcadeTokenCreationResultDisplay({
               </div>
               <div>
                 <strong>Decimals:</strong> {result.details?.decimals}
+              </div>
+              <div>
+                <strong>ACL Mode:</strong> Allowlist
               </div>
               <div>
                 <strong>Extensions:</strong>{' '}

--- a/packages/ui/src/app/dashboard/create/arcade-token/page.tsx
+++ b/packages/ui/src/app/dashboard/create/arcade-token/page.tsx
@@ -10,6 +10,7 @@ import {
   CardTitle,
 } from '@/components/ui/card';
 import Link from 'next/link';
+import { CreateTemplateSidebar } from '@/components/CreateTemplateSidebar';
 import { SelectedWalletAccountContext } from '@/context/SelectedWalletAccountContext';
 import { ChainContext } from '@/context/ChainContext';
 import { useWalletAccountTransactionSendingSigner } from '@solana/react';
@@ -32,7 +33,7 @@ function ArcadeTokenCreateWithWallet({
 
   return (
     <div className="flex-1 p-8">
-      <div className="max-w-4xl mx-auto">
+      <div className="max-w-6xl mx-auto">
         <div className="flex items-center mb-8">
           <Link href="/dashboard/create">
             <Button variant="ghost" className="mr-4">
@@ -47,9 +48,36 @@ function ArcadeTokenCreateWithWallet({
           </div>
         </div>
 
-        <ArcadeTokenCreateForm
-          transactionSendingSigner={transactionSendingSigner}
-        />
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+          <div className="lg:col-span-2 min-w-0">
+            <ArcadeTokenCreateForm
+              transactionSendingSigner={transactionSendingSigner}
+            />
+          </div>
+          <aside className="space-y-4">
+            <CreateTemplateSidebar
+              description={
+                <>
+                  Arcade tokens are closed-loop tokens suitable for in-app or
+                  game economies that require an allowlist.
+                </>
+              }
+              coreCapabilityKeys={[
+                'closedLoopAllowlistOnly',
+                'pausable',
+                'metadata',
+                'permanentDelegate',
+              ]}
+              enabledExtensionKeys={[
+                'extMetadata',
+                'extPausable',
+                'extDefaultAccountStateAllow',
+                'extPermanentDelegate',
+              ]}
+              standardKeys={['sRFC37', 'gatingProgram']}
+            />
+          </aside>
+        </div>
       </div>
     </div>
   );

--- a/packages/ui/src/app/dashboard/create/stablecoin/StablecoinCreateForm.tsx
+++ b/packages/ui/src/app/dashboard/create/stablecoin/StablecoinCreateForm.tsx
@@ -52,23 +52,29 @@ export function StablecoinCreateForm({
       );
 
       if (result.success && result.mintAddress) {
-        const addrValue: unknown = (transactionSendingSigner as {
-          address?: unknown;
-        }).address;
+        const addrValue: unknown = (
+          transactionSendingSigner as {
+            address?: unknown;
+          }
+        ).address;
         const defaultAuthority =
           typeof addrValue === 'string'
             ? addrValue
-            : typeof addrValue === 'object' && addrValue !== null && 'toString' in addrValue
-            ? String((addrValue as { toString: () => string }).toString())
-            : '';
+            : typeof addrValue === 'object' &&
+                addrValue !== null &&
+                'toString' in addrValue
+              ? String((addrValue as { toString: () => string }).toString())
+              : '';
 
-        const derivedMintAuthority = stablecoinOptions.mintAuthority || defaultAuthority;
+        const derivedMintAuthority =
+          stablecoinOptions.mintAuthority || defaultAuthority;
         const derivedMetadataAuthority =
           stablecoinOptions.metadataAuthority || derivedMintAuthority;
         const derivedPausableAuthority =
           stablecoinOptions.pausableAuthority || derivedMintAuthority;
         const derivedConfidentialBalancesAuthority =
-          stablecoinOptions.confidentialBalancesAuthority || derivedMintAuthority;
+          stablecoinOptions.confidentialBalancesAuthority ||
+          derivedMintAuthority;
         const derivedPermanentDelegateAuthority =
           stablecoinOptions.permanentDelegateAuthority || derivedMintAuthority;
         // Create token display object
@@ -162,13 +168,17 @@ export function StablecoinCreateForm({
               </p>
             </div>
             <div className="p-6 space-y-2">
-              <label className="block text-sm font-medium">Access Control Mode</label>
+              <label className="block text-sm font-medium">
+                Access Control Mode
+              </label>
               <select
                 className="w-full p-3 border rounded-lg"
                 value={stablecoinOptions.aclMode || 'blocklist'}
                 onChange={e => handleInputChange('aclMode', e.target.value)}
               >
-                <option value="blocklist">Blocklist (for sanctions, etc)</option>
+                <option value="blocklist">
+                  Blocklist (for sanctions, etc)
+                </option>
                 <option value="allowlist">Allowlist (Closed-loop)</option>
               </select>
             </div>

--- a/packages/ui/src/app/dashboard/create/stablecoin/StablecoinCreationResult.tsx
+++ b/packages/ui/src/app/dashboard/create/stablecoin/StablecoinCreationResult.tsx
@@ -3,6 +3,7 @@ import { Button } from '@/components/ui/button';
 import { DollarSign, CheckCircle, Settings } from 'lucide-react';
 import { StablecoinCreationResult } from '@/types/token';
 import Link from 'next/link';
+import { CopyableExplorerField } from '@/components/CopyableExplorerField';
 
 interface StablecoinCreationResultProps {
   result: StablecoinCreationResult;
@@ -38,18 +39,18 @@ export function StablecoinCreationResultDisplay({
                 dashboard
               </span>
             </div>
-            <div>
-              <strong>Mint Address:</strong>
-              <code className="ml-2 bg-muted px-2 py-1 rounded text-sm">
-                {result.mintAddress}
-              </code>
-            </div>
-            <div>
-              <strong>Transaction:</strong>
-              <code className="ml-2 bg-muted px-2 py-1 rounded text-sm">
-                {result.transactionSignature}
-              </code>
-            </div>
+            <CopyableExplorerField
+              label="Mint Address"
+              value={result.mintAddress}
+              kind="address"
+              cluster="devnet"
+            />
+            <CopyableExplorerField
+              label="Transaction"
+              value={result.transactionSignature}
+              kind="tx"
+              cluster="devnet"
+            />
             <div className="text-sm text-muted-foreground">
               Your stablecoin has been successfully created with the following
               parameters:
@@ -65,8 +66,45 @@ export function StablecoinCreationResultDisplay({
                 <strong>Decimals:</strong> {result.details?.decimals}
               </div>
               <div>
+                <strong>ACL Mode:</strong> {result.details?.aclMode === 'allowlist' ? 'Allowlist' : 'Blocklist'}
+              </div>
+              <div>
                 <strong>Extensions:</strong>{' '}
                 {result.details?.extensions?.join(', ')}
+              </div>
+            </div>
+
+            <div className="pt-2 text-sm text-muted-foreground">Authorities</div>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-3 text-sm">
+              <div>
+                <strong>Mint Authority:</strong>{' '}
+                <code className="bg-muted px-1.5 py-0.5 rounded text-xs">
+                  {result.details?.mintAuthority}
+                </code>
+              </div>
+              <div>
+                <strong>Metadata Authority:</strong>{' '}
+                <code className="bg-muted px-1.5 py-0.5 rounded text-xs">
+                  {result.details?.metadataAuthority}
+                </code>
+              </div>
+              <div>
+                <strong>Pausable Authority:</strong>{' '}
+                <code className="bg-muted px-1.5 py-0.5 rounded text-xs">
+                  {result.details?.pausableAuthority}
+                </code>
+              </div>
+              <div>
+                <strong>Confidential Balances Authority:</strong>{' '}
+                <code className="bg-muted px-1.5 py-0.5 rounded text-xs">
+                  {result.details?.confidentialBalancesAuthority}
+                </code>
+              </div>
+              <div className="md:col-span-2">
+                <strong>Permanent Delegate Authority:</strong>{' '}
+                <code className="bg-muted px-1.5 py-0.5 rounded text-xs">
+                  {result.details?.permanentDelegateAuthority}
+                </code>
               </div>
             </div>
 

--- a/packages/ui/src/app/dashboard/create/stablecoin/StablecoinCreationResult.tsx
+++ b/packages/ui/src/app/dashboard/create/stablecoin/StablecoinCreationResult.tsx
@@ -66,7 +66,10 @@ export function StablecoinCreationResultDisplay({
                 <strong>Decimals:</strong> {result.details?.decimals}
               </div>
               <div>
-                <strong>ACL Mode:</strong> {result.details?.aclMode === 'allowlist' ? 'Allowlist' : 'Blocklist'}
+                <strong>ACL Mode:</strong>{' '}
+                {result.details?.aclMode === 'allowlist'
+                  ? 'Allowlist'
+                  : 'Blocklist'}
               </div>
               <div>
                 <strong>Extensions:</strong>{' '}
@@ -74,7 +77,9 @@ export function StablecoinCreationResultDisplay({
               </div>
             </div>
 
-            <div className="pt-2 text-sm text-muted-foreground">Authorities</div>
+            <div className="pt-2 text-sm text-muted-foreground">
+              Authorities
+            </div>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-3 text-sm">
               <div>
                 <strong>Mint Authority:</strong>{' '}

--- a/packages/ui/src/app/dashboard/create/stablecoin/page.tsx
+++ b/packages/ui/src/app/dashboard/create/stablecoin/page.tsx
@@ -10,6 +10,7 @@ import {
   CardTitle,
 } from '@/components/ui/card';
 import Link from 'next/link';
+import { CreateTemplateSidebar } from '@/components/CreateTemplateSidebar';
 import { SelectedWalletAccountContext } from '@/context/SelectedWalletAccountContext';
 import { ChainContext } from '@/context/ChainContext';
 import { useWalletAccountTransactionSendingSigner } from '@solana/react';
@@ -32,7 +33,7 @@ function StablecoinCreateWithWallet({
 
   return (
     <div className="flex-1 p-8">
-      <div className="max-w-4xl mx-auto">
+      <div className="max-w-6xl mx-auto">
         <div className="flex items-center mb-8">
           <Link href="/dashboard/create">
             <Button variant="ghost" className="mr-4">
@@ -47,9 +48,39 @@ function StablecoinCreateWithWallet({
           </div>
         </div>
 
-        <StablecoinCreateForm
-          transactionSendingSigner={transactionSendingSigner}
-        />
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+          <div className="lg:col-span-2 min-w-0">
+            <StablecoinCreateForm
+              transactionSendingSigner={transactionSendingSigner}
+            />
+          </div>
+          <aside className="space-y-4">
+            <CreateTemplateSidebar
+              description={
+                <>
+                  This stablecoin template is designed for regulatory-compliant
+                  issuance with strong controls and safety features.
+                </>
+              }
+              coreCapabilityKeys={[
+                'metadata',
+                'accessControls',
+                'pausable',
+                'permanentDelegate',
+                'confidentialBalances',
+                'confidentialMintBurn',
+              ]}
+              enabledExtensionKeys={[
+                'extMetadata',
+                'extPausable',
+                'extDefaultAccountStateAllowOrBlock',
+                'extConfidentialBalances',
+                'extPermanentDelegate',
+              ]}
+              standardKeys={['sRFC37', 'gatingProgram']}
+            />
+          </aside>
+        </div>
       </div>
     </div>
   );

--- a/packages/ui/src/components/CopyableExplorerField.tsx
+++ b/packages/ui/src/components/CopyableExplorerField.tsx
@@ -1,0 +1,59 @@
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { ExternalLink } from 'lucide-react';
+
+interface CopyableExplorerFieldProps {
+  label: string;
+  value?: string;
+  kind: 'address' | 'tx';
+  cluster?: 'devnet' | 'testnet' | 'mainnet-beta';
+}
+
+export function CopyableExplorerField({
+  label,
+  value,
+  kind,
+  cluster = 'devnet',
+}: CopyableExplorerFieldProps) {
+  const [copied, setCopied] = useState(false);
+  const explorerPath = kind === 'address' ? 'address' : 'tx';
+
+  const onCopy = () => {
+    if (!value) return;
+    navigator.clipboard.writeText(value);
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 1500);
+  };
+
+  return (
+    <div>
+      <strong>{label}:</strong>
+      <div className="mt-1 flex items-center gap-2 min-w-0">
+        <div className="max-w-full overflow-x-auto inline-block align-middle">
+          <code
+            className="ml-2 bg-muted px-2 py-1 rounded text-sm whitespace-nowrap inline-block cursor-pointer hover:bg-muted/80"
+            title="Click to copy"
+            onClick={onCopy}
+          >
+            {value}
+          </code>
+        </div>
+        {copied && <span className="text-green-600 text-xs">Copied</span>}
+        {value && (
+          <Button asChild variant="outline" size="sm" type="button">
+            <a
+              href={`https://explorer.solana.com/${explorerPath}/${value}?cluster=${cluster}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label={`Open ${label.toLowerCase()} in Solana Explorer (${cluster})`}
+            >
+              <ExternalLink className="h-4 w-4" />
+            </a>
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+

--- a/packages/ui/src/components/CopyableExplorerField.tsx
+++ b/packages/ui/src/components/CopyableExplorerField.tsx
@@ -55,5 +55,3 @@ export function CopyableExplorerField({
     </div>
   );
 }
-
-

--- a/packages/ui/src/components/CreateTemplateSidebar.tsx
+++ b/packages/ui/src/components/CreateTemplateSidebar.tsx
@@ -62,7 +62,8 @@ export function CreateTemplateSidebar({
             <ul className="list-disc pl-5 mt-2 space-y-1">
               {resolvedExtensions.length > 0 && (
                 <li>
-                  <strong>Token extensions</strong>: {resolvedExtensions.map((n, i) => (
+                  <strong>Token extensions</strong>:{' '}
+                  {resolvedExtensions.map((n, i) => (
                     <span key={i}>
                       {n}
                       {i < resolvedExtensions.length - 1 ? ', ' : ''}
@@ -85,5 +86,3 @@ export function CreateTemplateSidebar({
     </div>
   );
 }
-
-

--- a/packages/ui/src/components/CreateTemplateSidebar.tsx
+++ b/packages/ui/src/components/CreateTemplateSidebar.tsx
@@ -1,0 +1,89 @@
+import { CardHeader, CardContent, CardTitle } from '@/components/ui/card';
+import { ReactNode } from 'react';
+import {
+  CapabilityKey,
+  ExtensionKey,
+  capabilityNodes,
+  extensionNodes,
+} from '@/components/capabilities/registry';
+
+interface CreateTemplateSidebarProps {
+  aboutTitle?: string;
+  description: ReactNode;
+  coreCapabilities?: ReactNode[];
+  enabledExtensions?: ReactNode[];
+  standards?: ReactNode[];
+  coreCapabilityKeys?: CapabilityKey[];
+  enabledExtensionKeys?: ExtensionKey[];
+  standardKeys?: CapabilityKey[];
+}
+
+export function CreateTemplateSidebar({
+  aboutTitle = 'About this template',
+  description,
+  coreCapabilities,
+  enabledExtensions,
+  standards,
+  coreCapabilityKeys,
+  enabledExtensionKeys,
+  standardKeys,
+}: CreateTemplateSidebarProps) {
+  const resolvedCore = coreCapabilities
+    ? coreCapabilities
+    : (coreCapabilityKeys || []).map(k => capabilityNodes[k]);
+  const resolvedExtensions = enabledExtensions
+    ? enabledExtensions
+    : (enabledExtensionKeys || []).map(k => extensionNodes[k]);
+  const resolvedStandards = standards
+    ? standards
+    : (standardKeys || []).map(k => capabilityNodes[k]);
+  return (
+    <div className="rounded-lg border">
+      <CardHeader>
+        <CardTitle className="text-lg font-semibold">{aboutTitle}</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4 text-sm">
+        <div className="text-muted-foreground">{description}</div>
+
+        {resolvedCore?.length > 0 && (
+          <div>
+            <h4 className="font-medium">Core capabilities</h4>
+            <ul className="list-disc pl-5 mt-2 space-y-1">
+              {resolvedCore.map((item, idx) => (
+                <li key={idx}>{item}</li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        {(resolvedExtensions.length > 0 || resolvedStandards.length > 0) && (
+          <div>
+            <h4 className="font-medium">Underlying standards</h4>
+            <ul className="list-disc pl-5 mt-2 space-y-1">
+              {resolvedExtensions.length > 0 && (
+                <li>
+                  <strong>Token extensions</strong>: {resolvedExtensions.map((n, i) => (
+                    <span key={i}>
+                      {n}
+                      {i < resolvedExtensions.length - 1 ? ', ' : ''}
+                    </span>
+                  ))}
+                </li>
+              )}
+              {resolvedStandards.map((item, idx) => (
+                <li key={idx}>{item}</li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        <div className="text-muted-foreground">
+          You can manage lists and authorities later from the token management
+          dashboard.
+        </div>
+      </CardContent>
+    </div>
+  );
+}
+
+

--- a/packages/ui/src/components/capabilities/registry.tsx
+++ b/packages/ui/src/components/capabilities/registry.tsx
@@ -98,7 +98,8 @@ export const capabilityNodes: Record<CapabilityKey, ReactNode> = {
       >
         Standard
       </a>{' '}
-      for allowlist/blocklist management with a gating program for account access. Enables permissionless thaw/freeze for seamless UX flows.
+      for allowlist/blocklist management with a gating program for account
+      access. Enables permissionless thaw/freeze for seamless UX flows.
     </>
   ),
   gatingProgram: (

--- a/packages/ui/src/components/capabilities/registry.tsx
+++ b/packages/ui/src/components/capabilities/registry.tsx
@@ -1,0 +1,168 @@
+import { ReactNode } from 'react';
+
+export type CapabilityKey =
+  | 'metadata'
+  | 'accessControls'
+  | 'closedLoopAllowlistOnly'
+  | 'pausable'
+  | 'permanentDelegate'
+  | 'confidentialBalances'
+  | 'confidentialMintBurn'
+  | 'sRFC37'
+  | 'gatingProgram';
+
+export type ExtensionKey =
+  | 'extMetadata'
+  | 'extPausable'
+  | 'extDefaultAccountStateAllowOrBlock'
+  | 'extDefaultAccountStateAllow'
+  | 'extPermanentDelegate'
+  | 'extConfidentialBalances';
+
+export const capabilityNodes: Record<CapabilityKey, ReactNode> = {
+  metadata: (
+    <>
+      <strong>Metadata</strong>: Onchain metadata with name, symbol, and URI.
+      URI should point to a JSON file that follows the{' '}
+      <a
+        href="https://developers.metaplex.com/token-metadata/token-standard"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Metaplex Metadata Standard
+      </a>{' '}
+      spec.
+    </>
+  ),
+  accessControls: (
+    <>
+      <strong>Configurable access controls</strong>: Allowlist (closed-loop) or
+      blocklist (open-loop). Uses the{' '}
+      <a
+        href="https://forum.solana.com/t/srfc-37-efficient-block-allow-list-token-standard/4036"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        sRFC-37
+      </a>{' '}
+      standard for list management.
+    </>
+  ),
+  closedLoopAllowlistOnly: (
+    <>
+      <strong>Closed-loop (allowlist only)</strong>: Account creation and
+      transfers restricted to an explicit allowlist using{' '}
+      <a
+        href="https://forum.solana.com/t/srfc-37-efficient-block-allow-list-token-standard/4036"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        sRFC-37
+      </a>
+      .
+    </>
+  ),
+  pausable: (
+    <>
+      <strong>Pausable</strong>: Pause all interactions with the token in
+      emergencies.
+    </>
+  ),
+  permanentDelegate: (
+    <>
+      <strong>Permanent delegate</strong>: Authority to transfer or burn any
+      token from any account. Useful for compliance and managed UX flows.
+    </>
+  ),
+  confidentialBalances: (
+    <>
+      <strong>Confidential balances</strong>: Feature under audit enabling
+      transfers with encrypted amounts. Balances are not revealed to anyone but
+      the token owner and an optional auditor.
+    </>
+  ),
+  confidentialMintBurn: (
+    <>
+      <strong>Confidential mint/burn</strong>: Feature under audit enabling
+      mint/burn with encrypted amounts. Amounts are not revealed to anyone but
+      the token owner and an optional auditor.
+    </>
+  ),
+  sRFC37: (
+    <>
+      <strong>sRFC-37</strong>:{' '}
+      <a
+        href="https://forum.solana.com/t/srfc-37-efficient-block-allow-list-token-standard/4036"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Standard
+      </a>{' '}
+      for allowlist/blocklist management with a gating program for account access. Enables permissionless thaw/freeze for seamless UX flows.
+    </>
+  ),
+  gatingProgram: (
+    <>
+      <strong>Gating program</strong>: Enables the freeze authority to manage
+      allowlist/blocklist. Can be replaced with a custom program for complex
+      gating (e.g., jurisdictional KYC proofs).
+    </>
+  ),
+};
+
+export const extensionNodes: Record<ExtensionKey, ReactNode> = {
+  extMetadata: (
+    <a
+      href="https://www.solana-program.com/docs/token-2022/extensions#metadata"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      Metadata
+    </a>
+  ),
+  extPausable: (
+    <a
+      href="https://www.solana-program.com/docs/token-2022/extensions#pausable"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      Pausable
+    </a>
+  ),
+  extDefaultAccountStateAllowOrBlock: (
+    <a
+      href="https://www.solana-program.com/docs/token-2022/extensions#default-account-state"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      Default Account State (allowlist/blocklist)
+    </a>
+  ),
+  extDefaultAccountStateAllow: (
+    <a
+      href="https://www.solana-program.com/docs/token-2022/extensions#default-account-state"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      Default Account State (allowlist)
+    </a>
+  ),
+  extPermanentDelegate: (
+    <a
+      href="https://www.solana-program.com/docs/token-2022/extensions#permanent-delegate"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      Permanent Delegate
+    </a>
+  ),
+  extConfidentialBalances: (
+    <a
+      href="https://solana.com/docs/tokens/extensions/confidential-transfer"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      Confidential Balances
+    </a>
+  ),
+};

--- a/packages/ui/src/lib/issuance/stablecoin.ts
+++ b/packages/ui/src/lib/issuance/stablecoin.ts
@@ -84,6 +84,7 @@ export const createStablecoin = async (
       mintAuthority,
       mintKeypair,
       signer, // Use wallet as fee payer
+      options.aclMode || 'blocklist',
       metadataAuthority,
       pausableAuthority,
       confidentialBalancesAuthority,

--- a/packages/ui/src/types/token.ts
+++ b/packages/ui/src/types/token.ts
@@ -22,6 +22,7 @@ export interface StablecoinOptions {
   symbol: string;
   decimals: string;
   uri?: string;
+  aclMode?: 'allowlist' | 'blocklist';
   mintAuthority?: string;
   metadataAuthority?: string;
   pausableAuthority?: string;
@@ -39,6 +40,7 @@ export interface StablecoinCreationResult {
     name: string;
     symbol: string;
     decimals: number;
+    aclMode?: 'allowlist' | 'blocklist';
     mintAuthority: string;
     metadataAuthority: string;
     pausableAuthority: string;


### PR DESCRIPTION
### PR title
Create flow UX upgrades: sidebar + docs, ACL toggle, copy-to-clipboard, explorer links; centralized sidebar content; arcade-token parity; overflow fixes

### Summary
- Stablecoin create:
  - Added right-hand sidebar explaining capabilities, token extensions, and underlying standards.
  - Added ACL mode toggle (allowlist/blocklist). Wired through `StablecoinOptions` to transaction builder.
  - Creation result: shows ACL mode, authorities, copy-to-clipboard with inline feedback, and explorer buttons.
  - Layout: two-column grid, prevents hash overflow (`min-w-0`, horizontal scroll on long values).
  - Hide “Create” after success; keep “Reset” to start over.

- Arcade token create:
  - Enforced closed-loop allowlist model and displayed “ACL Mode: Allowlist”.
  - Same sidebar pattern + explorer/copy UX and hide-on-success flow.

- Centralization:
  - New `CreateTemplateSidebar` and `capabilities/registry` with reusable capability and extension nodes.
  - All extension links point to `solana-program.com` per instruction.
  - Added `CopyableExplorerField` to dedupe the copy/explorer UI.

- Types/SDK integration:
  - UI types: `StablecoinOptions.aclMode?: 'allowlist' | 'blocklist'`; `StablecoinCreationResult.details.aclMode`.
  - Pass `aclMode` into `createStablecoinInitTransaction` in correct arg position.

### Why
- Improve clarity around what each template does, the enabled extensions, and standards in use.
- Provide product-focused, centralized content to avoid duplication and drift.
- Add a closed/open loop choice for stablecoin issuers; make arcade token clearly closed-loop.
- Fix UX papercuts (overflowing hashes, accidental resubmits on link clicks, lack of copy affordance).

### Screens/UX
- Two-column layout: form + sidebar.
- Result cards: hashes are horizontally scrollable, clickable to copy, with external explorer buttons.
- Create button hidden post-success; reset provided.

### Developer notes
- Sidebar content centralized via `components/CreateTemplateSidebar.tsx` + `components/capabilities/registry.tsx`.
- Registry includes capability keys (`metadata`, `accessControls`, `closedLoopAllowlistOnly`, `pausable`, `permanentDelegate`, `confidentialBalances`, `confidentialMintBurn`, `sRFC37`, `gatingProgram`) and extension keys (`extMetadata`, `extPausable`, `extDefaultAccountStateAllowOrBlock`, `extDefaultAccountStateAllow`, `extPermanentDelegate`, `extConfidentialBalances`).
- Explorer links use Button `asChild` anchors to avoid form submission.

### Affected packages/files (high level)
- ui
  - `app/.../stablecoin/page.tsx` (sidebar + layout)
  - `app/.../stablecoin/StablecoinCreateForm.tsx` (ACL toggle, result handling, hide-on-success)
  - `app/.../stablecoin/StablecoinCreationResult.tsx` (copy/explorer, details)
  - `app/.../arcade-token/page.tsx` (sidebar + layout)
  - `app/.../arcade-token/ArcadeTokenCreateForm.tsx` (hide-on-success)
  - `app/.../arcade-token/ArcadeTokenCreationResult.tsx` (copy/explorer, ACL display)
  - `components/CreateTemplateSidebar.tsx`
  - `components/capabilities/registry.tsx`
  - `components/CopyableExplorerField.tsx`
  - `lib/issuance/stablecoin.ts` (pass `aclMode`)
  - `types/token.ts` (new fields)
- sdk (read-only relied upon): `templates/stablecoin.ts` already accepts `aclMode`

### Backwards compatibility
- `aclMode` is optional and defaults to blocklist in UI; no breaking changes to callers.
- Links standardized to `solana-program.com`.

### Testing
- Stablecoin:
  - Choose allowlist; create → result shows “ACL Mode: Allowlist”, authorities populated with connected wallet when fields omitted.
  - Toggle blocklist; result shows “ACL Mode: Blocklist”.
  - Click mint/tx values to copy; “Copied” appears; explorer buttons open new tab; no extra transaction prompts.
  - Create button hidden after success; “Reset” clears state.
  - Long hashes do not overflow with sidebar present.

- Arcade token:
  - Create; result shows “ACL Mode: Allowlist”.
  - Copy/explorer behavior identical; create button hidden post-success; reset works.

- Lint/type-check: clean.

### References
- Pausable (Token-2022) `solana-program.com` docs: [link](https://www.solana-program.com/docs/token-2022/extensions#pausable)
- Default Account State: [link](https://www.solana-program.com/docs/token-2022/extensions#default-account-state)
- Metadata: [link](https://www.solana-program.com/docs/token-2022/extensions#metadata)
- Permanent Delegate: [link](https://www.solana-program.com/docs/token-2022/extensions#permanent-delegate)
- Confidential Transfers overview: [link](https://solana.com/docs/tokens/extensions/confidential-transfer)
- sRFC-37 discussion: [link](https://forum.solana.com/t/srfc-37-efficient-block-allow-list-token-standard/4036)

### Checklist
- [x] Explainer sidebar added and centralized across templates
- [x] Stablecoin ACL toggle end-to-end
- [x] Arcade token closed-loop enforced and surfaced
- [x] Copy-to-clipboard + explorer links with safe button behavior
- [x] Overflow fixes for long hashes
- [x] Types updated; integration with SDK preserved
- [x] Lint/type checks pass
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Enhances token creation UX with sidebars, ACL toggles, and improved result displays for stablecoin and arcade tokens, centralizing content and adding reusability features.
> 
>   - **Stablecoin Creation**:
>     - Added sidebar with token capabilities and standards in `page.tsx`.
>     - Introduced ACL mode toggle in `StablecoinCreateForm.tsx`.
>     - Enhanced result display with ACL mode and authorities in `StablecoinCreationResult.tsx`.
>   - **Arcade Token Creation**:
>     - Enforced allowlist model in `ArcadeTokenCreateForm.tsx`.
>     - Added sidebar and result display enhancements in `page.tsx` and `ArcadeTokenCreationResult.tsx`.
>   - **Centralization and Reusability**:
>     - Created `CreateTemplateSidebar` for centralized sidebar content.
>     - Added `CopyableExplorerField` for copy-to-clipboard and explorer links.
>     - Updated `capabilities/registry.tsx` with capability and extension nodes.
>   - **Types and SDK Integration**:
>     - Updated `StablecoinOptions` and `StablecoinCreationResult` in `types/token.ts`.
>     - Integrated `aclMode` into `createStablecoinInitTransaction` in `stablecoin.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gitteri%2Fmosaic&utm_source=github&utm_medium=referral)<sup> for b24d9a90e68707c36ab59e9115499a87754f082c. You can [customize](https://app.ellipsis.dev/gitteri/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->